### PR TITLE
Make buffer loading functions public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -505,7 +505,7 @@ pub fn load_mtl(file_name: &Path) -> MTLLoadResult {
 
 /// Load the various meshes in an OBJ buffer. `base_path` specifies the path prefix to apply to
 /// referenced material libs
-fn load_obj_buf<B: BufRead>(reader: &mut B, base_path: Option<&Path>) -> LoadResult {
+pub fn load_obj_buf<B: BufRead>(reader: &mut B, base_path: Option<&Path>) -> LoadResult {
     let mut models = Vec::new();
     let mut materials = Vec::new();
     let mut mat_map = HashMap::new();
@@ -612,7 +612,7 @@ fn load_obj_buf<B: BufRead>(reader: &mut B, base_path: Option<&Path>) -> LoadRes
 }
 
 /// Load the various materials in a MTL buffer
-fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
+pub fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
     let mut materials = Vec::new();
     let mut mat_map = HashMap::new();
     // The current material being parsed


### PR DESCRIPTION
Allows other libraries to take care of loading the obj files into memory