### PR TITLE
fix line trimming issue for `material.unknown_param`s

### DIFF
--- a/cornell_box.mtl
+++ b/cornell_box.mtl
@@ -1,7 +1,8 @@
 newmtl white
-Ka 0 0 0
-Kd 1 1 1
-Ks 0 0 0
+    Ka 0 0 0
+    Kd 1 1 1
+    Ks 0 0 0
+    Ke 1 1 1
 
 newmtl red
 Ka 0 0 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,7 +679,7 @@ fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
     let mut cur_mat = Material::empty();
     for line in reader.lines() {
         let (line, mut words) = match line {
-            Ok(ref line) => (&line[..], line[..].split_whitespace()),
+            Ok(ref line) => (line.trim(), line[..].split_whitespace()),
             Err(e) => {
                 println!("tobj::load_obj - failed to read line due to {}", e);
                 return Err(LoadError::ReadError);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -180,6 +180,7 @@ fn test_cornell() {
     assert_eq!(mat.ambient, [0.0, 0.0, 0.0]);
     assert_eq!(mat.diffuse, [1.0, 1.0, 1.0]);
     assert_eq!(mat.specular, [0.0, 0.0, 0.0]);
+    assert_eq!(mat.unknown_param.get("Ke").map(|s| s.as_ref()), Some("1 1 1"));
 
     // Verify red material loaded properly
     assert_eq!(mats[1].name, "red");


### PR DESCRIPTION
Hi there, thanks for your awesome lib!
I came across a tiny nitpicking when using it though, thus this PR.
When loading unknown parameters from `.mtl` files with leading whitespaces, currently those whitespaces are incorrectly accounted for.

E.g.:
```text
# test.mtl
# this file contains lines with leading whitespaces
newmtl white
 Ka 0 0 0
 Kd 1 1 1
 Ks 0 0 0
 # "Ke" is unrecognized
 Ke 1 1 1
```

```rust
let mat = load_mtl("test.mtl".as_ref()).unwrap().0[0];
/// This should print "1 1 1", however it prints out "e 1 1 1" instead
print!("{}", mat.unknown_param.get("Ke").unwrap());
```

This PR adds line trimming to fix this, also updates tests to verify the result. Hope it'd be helpful!