### PR TITLE
Parse the illumination model of materials

### DIFF
--- a/cornell_box.mtl
+++ b/cornell_box.mtl
@@ -8,4 +8,5 @@ newmtl red
 Ka 0 0 0
 Kd 1 0 0
 Ks 0 0 0
+illum 2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,6 +254,9 @@ pub struct Material {
     /// file names specified in the MTL file. Referred to as dissolve to match the MTL file format
     /// specification
     pub dissolve_texture: String,
+    /// The illumnination model to use for this material. The different illumnination models are
+    /// specified in http://paulbourke.net/dataformats/mtl/
+    pub illumination_model: Option<u8>,
     /// Key value pairs of any unrecognized parameters encountered while parsing the material
     pub unknown_param: HashMap<String, String>,
 }
@@ -273,6 +276,7 @@ impl Material {
             specular_texture: String::new(),
             normal_texture: String::new(),
             dissolve_texture: String::new(),
+            illumination_model: None,
             unknown_param: HashMap::new(),
         }
     }
@@ -772,6 +776,16 @@ fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
                 match words.next() {
                     Some(tex) => cur_mat.dissolve_texture = tex.to_owned(),
                     None => return Err(LoadError::MaterialParseError),
+                }
+            }
+            Some("illum") => {
+                if let Some(p) = words.next() {
+                    match FromStr::from_str(p) {
+                        Ok(x) => cur_mat.illumination_model = Some(x),
+                        Err(_) => return Err(LoadError::MaterialParseError),
+                    }
+                } else {
+                    return Err(LoadError::MaterialParseError);
                 }
             }
             Some(unknown) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -180,7 +180,9 @@ fn test_cornell() {
     assert_eq!(mat.ambient, [0.0, 0.0, 0.0]);
     assert_eq!(mat.diffuse, [1.0, 1.0, 1.0]);
     assert_eq!(mat.specular, [0.0, 0.0, 0.0]);
-    assert_eq!(mat.unknown_param.get("Ke").map(|s| s.as_ref()), Some("1 1 1"));
+    assert_eq!(mat.unknown_param.get("Ke").map(|s| s.as_ref()),
+               Some("1 1 1"));
+    assert_eq!(mat.illumination_model, None);
 
     // Verify red material loaded properly
     assert_eq!(mats[1].name, "red");
@@ -188,6 +190,7 @@ fn test_cornell() {
     assert_eq!(mat.ambient, [0.0, 0.0, 0.0]);
     assert_eq!(mat.diffuse, [1.0, 0.0, 0.0]);
     assert_eq!(mat.specular, [0.0, 0.0, 0.0]);
+    assert_eq!(mat.illumination_model, Some(2));
 
     // Verify blue material loaded properly
     assert_eq!(mats[2].name, "blue");


### PR DESCRIPTION
Was initially going to do this as an enum, but settled on `u8` which leaves the exact interpretation up to the end user