### PR TITLE
Allow empty object and group names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -657,7 +657,7 @@ pub fn load_obj_buf<B, ML>(reader: &mut B, material_loader: ML) -> LoadResult
             Some("o") | Some("g") => {
                 // If we were already parsing an object then a new object name
                 // signals the end of the current one, so push it onto our list of objects
-                if !name.is_empty() && !tmp_faces.is_empty() {
+                if !tmp_faces.is_empty() {
                     models.push(Model::new(export_faces(&tmp_pos,
                                                         &tmp_texcoord,
                                                         &tmp_normal,
@@ -668,7 +668,7 @@ pub fn load_obj_buf<B, ML>(reader: &mut B, material_loader: ML) -> LoadResult
                 }
                 name = line[1..].trim().to_owned();
                 if name.is_empty() {
-                    return Err(LoadError::InvalidObjectName);
+                    name = "unnamed_object".to_owned();
                 }
             }
             Some("mtllib") => {
@@ -721,14 +721,12 @@ pub fn load_obj_buf<B, ML>(reader: &mut B, material_loader: ML) -> LoadResult
     }
     // For the last object in the file we won't encounter another object name to tell us when it's
     // done, so if we're parsing an object push the last one on the list as well
-    if !name.is_empty() {
-        models.push(Model::new(export_faces(&tmp_pos,
-                                            &tmp_texcoord,
-                                            &tmp_normal,
-                                            &tmp_faces,
-                                            mat_id),
-                               name));
-    }
+    models.push(Model::new(export_faces(&tmp_pos,
+                                        &tmp_texcoord,
+                                        &tmp_normal,
+                                        &tmp_faces,
+                                        mat_id),
+                            name));
     Ok((models, materials))
 }
 


### PR DESCRIPTION
Quixel Bridge exports model files that contain a group in the beginning of the file without a name. Judging by a comment in the model file, it was originally exported from Houdini. Trying to load this model currently fails with an `InvalidObjectName` error. This pull request changes the loader to allow groups and objects with an empty name. Additionally, all `name.is_empty()` checks are removed because the name could never be empty in the first place.