### PR TITLE
Add Clone, Copy and PartialEq to LoadError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,7 @@ impl Material {
 }
 
 /// Possible errors that may occur while loading OBJ and MTL files
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LoadError {
     OpenFileFailed,
     ReadError,


### PR DESCRIPTION
These might be useful in some scenarios, eg. when comparing errors in tests.