### PR TITLE
Fix deprecated Error::description

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,13 +296,7 @@ pub enum LoadError {
 
 impl fmt::Display for LoadError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        f.write_str(self.description())
-    }
-}
-
-impl Error for LoadError {
-    fn description(&self) -> &str {
-        match *self {
+        let msg = match *self {
             LoadError::OpenFileFailed => "open file failed",
             LoadError::ReadError => "read error",
             LoadError::UnrecognizedCharacter => "unrecognized character",
@@ -313,10 +307,13 @@ impl Error for LoadError {
             LoadError::MaterialParseError => "material parse error",
             LoadError::InvalidObjectName => "invalid object name",
             LoadError::GenericFailure => "generic failure",
-        }
+        };
+
+        f.write_str(msg)
     }
 }
 
+impl Error for LoadError {}
 
 /// `LoadResult` is a result containing all the models loaded from the file and any materials from
 /// referenced material libraries, or an error that occured while loading


### PR DESCRIPTION
Deprecated since [Rust 1.42][1].

[1]: https://blog.rust-lang.org/2020/03/12/Rust-1.42.html#error:description-is-deprecated

Currently any user that calls `error.description()` will get a deprecation warning, but this won't prevent their code from compiling: `Error` has a [default implementation](https://github.com/rust-lang/rust/pull/50163) for `description()` (although the text won't be correct now, obviously).

If you want users that relied on this to still get the right text, I can instead add a function

```rust
impl LoadError {
    fn msg() -> &str {
        match *self {
            LoadError::OpenFileFailed => "open file failed",
            LoadError::ReadError => "read error",
            LoadError::UnrecognizedCharacter => "unrecognized character",
            LoadError::PositionParseError => "position parse error",
            LoadError::NormalParseError => "normal parse error",
            LoadError::TexcoordParseError => "texcoord parse error",
            LoadError::FaceParseError => "face parse error",
            LoadError::MaterialParseError => "material parse error",
            LoadError::InvalidObjectName => "invalid object name",
            LoadError::GenericFailure => "generic failure",
        }
    }
}
```

and then use that in both `description()` and the `Display` impl.