### PR TITLE
Fix normal map parsing in MTL files

### DIFF
--- a/cornell_box.mtl
+++ b/cornell_box.mtl
@@ -12,6 +12,6 @@ illum 2
 map_Ka this ambient texture has spaces.jpg
 map_Kd this diffuse texture has spaces.jpg
 map_Ks this specular texture has spaces.jpg
-map_Ns this normal texture has spaces.jpg
+map_Bump this normal texture has spaces.jpg
 map_d this dissolve texture has spaces.jpg
 

--- a/cornell_box2.mtl
+++ b/cornell_box2.mtl
@@ -19,6 +19,6 @@ Ks 0 0 0
 map_Ka dummy_texture.png
 map_Kd dummy_texture.png
 map_Ks dummy_texture.png
-map_Ns dummy_texture.png
+map_Bump dummy_texture.png
 map_d dummy_texture.png
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -838,7 +838,11 @@ pub fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
                 Some("") | None => return Err(LoadError::MaterialParseError),
                 Some(tex) => cur_mat.specular_texture = tex.to_owned(),
             },
-            Some("map_Ns") => match line.get(6..).map(str::trim) {
+            Some("map_Bump") | Some("map_bump") => match line.get(8..).map(str::trim) {
+                Some("") | None => return Err(LoadError::MaterialParseError),
+                Some(tex) => cur_mat.normal_texture = tex.to_owned(),
+            },
+            Some("bump") => match line.get(4..).map(str::trim) {
                 Some("") | None => return Err(LoadError::MaterialParseError),
                 Some(tex) => cur_mat.normal_texture = tex.to_owned(),
             },


### PR DESCRIPTION
Hello. So it seems `tobj` parses paths to normal maps incorrectly.

According to [wiki](https://en.wikipedia.org/wiki/Wavefront_.obj_file#Texture_maps) and [MTL specification](http://paulbourke.net/dataformats/mtl/), `map_Ns` is related to specular highlights, not a normal map. And normal map is `bump` by specs, plus wiki says that many implementations use `map_bump` and blender exports `map_Bump`. I checked [this part in obj crate implementation](https://docs.rs/obj/0.9.1/src/obj/mtl.rs.html#233-237) and it also checks for these three: `bump`, `map_bump` and `map_Bump`.

And `Ns` probably needs another field in `Material` structure, not sure about the name. I don't touch it here.