### PR TITLE
Fix map_Ns parsing not to cut off the first character

### DIFF
--- a/cornell_box.mtl
+++ b/cornell_box.mtl
@@ -13,5 +13,6 @@ map_Ka this ambient texture has spaces.jpg
 map_Kd this diffuse texture has spaces.jpg
 map_Ks this specular texture has spaces.jpg
 map_Bump this normal texture has spaces.jpg
+map_Ns this shininess texture has spaces.jpg
 map_d this dissolve texture has spaces.jpg
 

--- a/cornell_box2.mtl
+++ b/cornell_box2.mtl
@@ -20,5 +20,6 @@ map_Ka dummy_texture.png
 map_Kd dummy_texture.png
 map_Ks dummy_texture.png
 map_Bump dummy_texture.png
+map_Ns dummy_texture.png
 map_d dummy_texture.png
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -891,7 +891,7 @@ pub fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
                 Some("") | None => return Err(LoadError::MaterialParseError),
                 Some(tex) => cur_mat.normal_texture = tex.to_owned(),
             },
-            Some("map_Ns") | Some("map_ns") => match line.get(8..).map(str::trim) {
+            Some("map_Ns") | Some("map_ns") => match line.get(6..).map(str::trim) {
                 Some("") | None => return Err(LoadError::MaterialParseError),
                 Some(tex) => cur_mat.shininess_texture = tex.to_owned(),
             },

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -282,6 +282,7 @@ fn validate_cornell(models: Vec<tobj::Model>, mats: Vec<tobj::Material>) {
     assert_eq!(mat.diffuse_texture, "this diffuse texture has spaces.jpg");
     assert_eq!(mat.specular_texture, "this specular texture has spaces.jpg");
     assert_eq!(mat.normal_texture, "this normal texture has spaces.jpg");
+    assert_eq!(mat.shininess_texture, "this shininess texture has spaces.jpg");
     assert_eq!(mat.dissolve_texture, "this dissolve texture has spaces.jpg");
 
     // Verify blue material loaded properly
@@ -316,6 +317,7 @@ fn validate_cornell(models: Vec<tobj::Model>, mats: Vec<tobj::Material>) {
     assert_eq!(mat.diffuse_texture, "dummy_texture.png");
     assert_eq!(mat.specular_texture, "dummy_texture.png");
     assert_eq!(mat.normal_texture, "dummy_texture.png");
+    assert_eq!(mat.shininess_texture, "dummy_texture.png");
     assert_eq!(mat.dissolve_texture, "dummy_texture.png");
 }
 


### PR DESCRIPTION
Hello! Nice module you have there. I thought I'd fix a small error in parsing. It looks like `map_Ns` parsing truncates the first character since the logic assumes it's as long as `map_Bump`. I've also added it to the tests so that this can be caught in the future in case the parsing logic changes.