### PR TITLE
Vertex colors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,3 +32,16 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+    nightly_features_linux:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose --all-features 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Arbitrary polygons may not behave as expected. The best solution would be to
 convert your mesh to solely consist of triangles in your modeling
 software.
 
-## Optional – Normals & Texture Coordinates
+## Optional – Normals, Texture Coordinates and Vertex Colors
 
-It is assumed that all meshes will at least have positions, but normals and
-texture coordinates are optional.
+It is assumed that all meshes will at least have positions, but normals, texture
+coordinates and vertex colors are optional.
 
-If no normals or texture coordinates are found then the corresponding `Vec`s
-for the `Mesh` will be empty.
+If no normals, texture coordinates or vertex colors are found, then the
+corresponding `Vec`s for the `Mesh` will be empty.
 
 ## Flat Data
 

--- a/obj/quad_colored_merge.obj
+++ b/obj/quad_colored_merge.obj
@@ -1,0 +1,12 @@
+# A simple triangle object with vertex colors for testing
+o Quad
+v 0 0 0 1 0 0 
+v 1 0 0 0 1 0
+v 0 1 0 0 0 1
+v 1 0 0 0 0 0
+v 0 1 0 0 0 1
+v 1 1 0 1 1 1 
+vn 0 0 1
+
+f 1//1 2//1 3//1
+f 4//1 5//1 6//1

--- a/obj/triangle_colored.obj
+++ b/obj/triangle_colored.obj
@@ -1,0 +1,8 @@
+# A simple triangle object with vertex colors for testing
+o Triangle
+v 0 0 0 1 0 0 
+v 1 0 0 0 1 0
+v 0 1 0 0 0 1
+
+f -3 -2 -1
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,11 @@ pub struct Mesh {
     /// through the `face_arities` until reaching the desired face, accumulating
     /// the number of vertices used so far.
     pub face_arities: Vec<u32>,
+    /// The indices for vertex colors. Only present when the
+    /// [`merging`](LoadOptions::merge_identical_points) feature is enabled, and
+    /// empty unless the corresponding load option is set to `true`.
+    #[cfg(feature = "merging")]
+    pub vertex_color_indices: Vec<u32>,
     /// The indices for texture coordinates. Can be omitted by setting
     /// `single_index` to `true`.
     pub texcoord_indices: Vec<u32>,
@@ -338,6 +343,8 @@ impl Default for Mesh {
             texcoords: Vec::new(),
             indices: Vec::new(),
             face_arities: Vec::new(),
+            #[cfg(feature = "merging")]
+            vertex_color_indices: Vec::new(),
             normal_indices: Vec::new(),
             texcoord_indices: Vec::new(),
             material_id: None,
@@ -1363,6 +1370,10 @@ fn export_faces_multi_index(
 
     #[cfg(feature = "merging")]
     if load_options.merge_identical_points {
+        if !mesh.vertex_color.is_empty() {
+            mesh.vertex_color_indices = mesh.indices.clone();
+            merge_identical_points::<3>(&mut mesh.vertex_color, &mut mesh.vertex_color_indices);
+        }
         merge_identical_points::<3>(&mut mesh.positions, &mut mesh.indices);
         merge_identical_points::<3>(&mut mesh.normals, &mut mesh.normal_indices);
         merge_identical_points::<2>(&mut mesh.texcoords, &mut mesh.texcoord_indices);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -107,15 +107,14 @@ fn simple_quad_colored_merge() {
         0.0, 0.0, 0.0,
         1.0, 0.0, 0.0,
         0.0, 1.0, 0.0,
-        1.0, 0.0, 0.0,
         1.0, 1.0, 0.0,
     ];
     assert_eq!(mesh.positions, expect_pos);
     // Verify the indices are loaded properly
-    let expect_idx = vec![0, 1, 2, 3, 1, 4];
+    let expect_idx = vec![0, 1, 2, 1, 2, 3];
     assert_eq!(mesh.indices, expect_idx);
 
-    // Verify vertex colors are loaded
+    // Verify vertex colors are loaded and correctly indexed.
     #[rustfmt::skip]
     let expect_vertex_color = vec![
         1.0, 0.0, 0.0,
@@ -125,6 +124,8 @@ fn simple_quad_colored_merge() {
         1.0, 1.0, 1.0,
     ];
     assert_eq!(mesh.vertex_color, expect_vertex_color);
+    let expect_vertex_color_index = vec![0, 1, 2, 3, 2, 4];
+    assert_eq!(mesh.vertex_color_indices, expect_vertex_color_index);
 }
 
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -78,6 +78,56 @@ fn simple_triangle_colored() {
 }
 
 #[test]
+#[cfg(feature = "merging")]
+fn simple_quad_colored_merge() {
+    let m = tobj::load_obj(
+        "obj/quad_colored_merge.obj",
+        &tobj::LoadOptions {
+            merge_identical_points: true,
+            ..Default::default()
+        },
+    );
+    assert!(m.is_ok());
+    let (models, mats) = m.unwrap();
+    let mats = mats.unwrap();
+    // We expect a single model with no materials
+    assert_eq!(models.len(), 1);
+    assert!(mats.is_empty());
+    // Confirm our quad is loaded correctly
+    assert_eq!(models[0].name, "Quad");
+    let mesh = &models[0].mesh;
+    assert_eq!(mesh.normals.len(), 3);
+    assert!(mesh.texcoords.is_empty());
+    assert_eq!(mesh.material_id, None);
+
+    // Verify each position is loaded properly and merged, with the exception of
+    // the 2nd and 4th vertices which have different vertex colors.
+    #[rustfmt::skip]
+    let expect_pos = vec![
+        0.0, 0.0, 0.0,
+        1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+        1.0, 0.0, 0.0,
+        1.0, 1.0, 0.0,
+    ];
+    assert_eq!(mesh.positions, expect_pos);
+    // Verify the indices are loaded properly
+    let expect_idx = vec![0, 1, 2, 3, 1, 4];
+    assert_eq!(mesh.indices, expect_idx);
+
+    // Verify vertex colors are loaded
+    #[rustfmt::skip]
+    let expect_vertex_color = vec![
+        1.0, 0.0, 0.0,
+        0.0, 1.0, 0.0,
+        0.0, 0.0, 1.0,
+        0.0, 0.0, 0.0,
+        1.0, 1.0, 1.0,
+    ];
+    assert_eq!(mesh.vertex_color, expect_vertex_color);
+}
+
+#[test]
 fn empty_name_triangle() {
     let m = tobj::load_obj(
         "obj/empty_name_triangle.obj",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -38,6 +38,43 @@ fn simple_triangle() {
     // Verify the indices are loaded properly
     let expect_idx = vec![0, 1, 2];
     assert_eq!(mesh.indices, expect_idx);
+
+    // Verify that there are no vertex colors
+    assert!(mesh.vertex_color.is_empty());
+}
+
+#[test]
+fn simple_triangle_colored() {
+    let m = tobj::load_obj(
+        "obj/triangle_colored.obj",
+        &tobj::LoadOptions {
+            single_index: true,
+            ..Default::default()
+        },
+    );
+    assert!(m.is_ok());
+    let (models, mats) = m.unwrap();
+    let mats = mats.unwrap();
+    // We expect a single model with no materials
+    assert_eq!(models.len(), 1);
+    assert!(mats.is_empty());
+    // Confirm our triangle is loaded correctly
+    assert_eq!(models[0].name, "Triangle");
+    let mesh = &models[0].mesh;
+    assert!(mesh.normals.is_empty());
+    assert!(mesh.texcoords.is_empty());
+    assert_eq!(mesh.material_id, None);
+
+    // Verify each position is loaded properly
+    let expect_pos = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+    assert_eq!(mesh.positions, expect_pos);
+    // Verify the indices are loaded properly
+    let expect_idx = vec![0, 1, 2];
+    assert_eq!(mesh.indices, expect_idx);
+
+    // Verify vertex colors are loaded
+    let expect_vertex_color = vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
+    assert_eq!(mesh.vertex_color, expect_vertex_color);
 }
 
 #[test]


### PR DESCRIPTION
Hi @Twinklebear, thanks so much for making and maintaining tobj! I wanted to make use of a model with vertex colors and decided to try to add the functionality to my favourite obj parsing crate, resolving #26 🙂

The changes are fairly straightforward:

- I added a new field called `vertex_color` to `Mesh`, following the style of `normals` and `texcoords`, and updated the README accordingly.
- After successfully parsing a position from a vertex line `v`, it will now add the vertex color on the same line if it is present.
- I added a `FaceColorOutOfBounds` error variant to match the existing OutOfBounds errors for normals and uv coords.
- I made `parse_floatn` take the `SplitWhitespace` by a mutable reference instead of by ownership in order to allow the iterator to be used again. As it will now only consume `n` items, it is now called a second time on `v` lines to see if there is a second trio of floats on it.
- All the tests still pass, and I added a `simple_triangle_colored` test that checks that the triangle file with vertex colors added is still parsed the same way, with the extra vertex color array now filled.

I still need to make this work with the `merge_identical_points` feature. As the vertex colors currently share indices with vertices, this is not entirely trivial. I did add a test for this, which is currently failing. As this test can only run on nightly with the `merging` feature, this will not show up with the current CI configuration.