### PR TITLE
Fix out of bound error if material name is missing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,7 +1742,12 @@ where
                 }
             }
             Some("usemtl") => {
-                let mat_name = line[7..].trim().to_owned();
+                let mat_name = line.split_once(" ")
+                    .unwrap_or_default()
+                    .1
+                    .trim()
+                    .to_owned();
+
                 if !mat_name.is_empty() {
                     let new_mat = mat_map.get(&mat_name).cloned();
                     // As materials are returned per-model, a new material within an object
@@ -1982,7 +1987,7 @@ pub fn load_mtl_buf<B: BufRead>(reader: &mut B) -> MTLLoadResult {
 ///
 /// ```
 ///async {
-///    
+///
 ///    use std::{env, fs::File, io::BufReader};
 ///
 ///    let dir = env::current_dir().unwrap();


### PR DESCRIPTION
When reading material names specified by the `usemtl` tag, the program may panic due to an out of bound bug if the material name is missing. This PR should fix this error by splitting the line at the first whitespace so that everything after the tag (including whitespace) belongs to the material name.

# Minimal reproduction

```rust
use tobj::{LoadOptions, load_obj_buf, load_mtl_buf};

fn main() {
    let mut data = "usemtl".as_bytes();
    load_obj_buf(&mut data, &LoadOptions::default(), |_| load_mtl_buf(&mut "".as_bytes()));
}
```
