### PR TITLE
cargo fuzz harness and fixes for bugs found

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,10 @@ default = ["ahash"]
 merging = []
 reordering = []
 async = []
+arbitrary = ["arbitrary/derive"]
 
 [dependencies]
+arbitrary = { version = "1.1.3", optional = true }
 ahash = { version = "0.7.6", optional = true }
 log = { version = "0.4.16", optional = true }
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "tobj-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+ahash = "*"
+
+[dependencies.tobj]
+path = ".."
+features = ["arbitrary"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "load_obj"
+path = "fuzz_targets/load_obj.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "load_mtl"
+path = "fuzz_targets/load_mtl.rs"
+test = false
+doc = false
+
+[profile.release]
+debug = true

--- a/fuzz/fuzz_targets/load_mtl.rs
+++ b/fuzz/fuzz_targets/load_mtl.rs
@@ -1,0 +1,7 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut cursor = std::io::Cursor::new(data);
+    let _ = tobj::load_mtl_buf(&mut cursor);
+});

--- a/fuzz/fuzz_targets/load_obj.rs
+++ b/fuzz/fuzz_targets/load_obj.rs
@@ -1,0 +1,28 @@
+#![no_main]
+use std::{io::Cursor, os::unix::prelude::OsStrExt, path::Path};
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: (&[u8], [&[u8]; 4], tobj::LoadOptions)| {
+    let (obj, mtls, options) = data;
+
+    let mtl_loader = move |path: &Path| {
+        let index: Option<usize> = path
+            .as_os_str()
+            .as_bytes()
+            .first()
+            .map(|c| (*c & 0b11).into());
+
+        if let Some(index) = index {
+            // load an mtl from one of the mtl bufs
+            let mut cursor = Cursor::new(mtls[index]);
+            tobj::load_mtl_buf(&mut cursor)
+        } else {
+            // path was empty, just give a default Ok
+            Ok((Vec::new(), ahash::AHashMap::new()))
+        }
+    };
+
+    let mut cursor = Cursor::new(obj);
+    let _ = tobj::load_obj_buf(&mut cursor, &options, mtl_loader);
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,7 @@ impl Default for Mesh {
 /// * [`GPU_LOAD_OPTIONS`] – if you display meshes on the GPU/in realtime.
 ///
 /// * [`OFFLINE_RENDERING_LOAD_OPTIONS`] – if you're rendering meshes with e.g. an offline path tracer or the like.
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy)]
 pub struct LoadOptions {
     /// Merge identical positions.


### PR DESCRIPTION
Hi! I wrote a couple fuzzers targeting file loading (mtl and obj). The mtl fuzzer did not find any issues (running for a couple hours). The obj loader, which is more complex of course, did find several panics when reading corrupting files.

The fuzzers are in the fuzz directory, as is common for [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).