### PR TITLE
Fix mtllib file name parsing bug for paths including spaces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1743,25 +1743,22 @@ where
             }
             Some("mtllib") => {
                 // File name can include spaces so we cannot rely on a SplitWhitespace iterator
-                if let Some(mtllib) = line.split_once(' ').unwrap_or_default().1.trim() {
-                    let mat_file = Path::new(mtllib).to_path_buf();
-                    match material_loader(mat_file.as_path()) {
-                        Ok((mut mats, map)) => {
-                            // Merge the loaded material lib with any currently loaded ones,
-                            // offsetting the indices of the appended
-                            // materials by our current length
-                            let mat_offset = materials.len();
-                            materials.append(&mut mats);
-                            for m in map {
-                                mat_map.insert(m.0, m.1 + mat_offset);
-                            }
-                        }
-                        Err(e) => {
-                            mtlresult = Err(e);
+                let mtllib = line.split_once(' ').unwrap_or_default().1.trim();
+                let mat_file = Path::new(mtllib).to_path_buf();
+                match material_loader(mat_file.as_path()) {
+                    Ok((mut mats, map)) => {
+                        // Merge the loaded material lib with any currently loaded ones,
+                        // offsetting the indices of the appended
+                        // materials by our current length
+                        let mat_offset = materials.len();
+                        materials.append(&mut mats);
+                        for m in map {
+                            mat_map.insert(m.0, m.1 + mat_offset);
                         }
                     }
-                } else {
-                    return Err(LoadError::MaterialParseError);
+                    Err(e) => {
+                        mtlresult = Err(e);
+                    }
                 }
             }
             Some("usemtl") => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1742,7 +1742,8 @@ where
                 }
             }
             Some("mtllib") => {
-                if let Some(mtllib) = words.next() {
+                // File name can include spaces so we cannot rely on a SplitWhitespace iterator
+                if let Some(mtllib) = line.split_once(' ').unwrap_or_default().1.trim() {
                     let mat_file = Path::new(mtllib).to_path_buf();
                     match material_loader(mat_file.as_path()) {
                         Ok((mut mats, map)) => {


### PR DESCRIPTION
Proposed fix to [Issue #63](https://github.com/Twinklebear/tobj/issues/63). Reused the expression found in the "usemtl" match branch for consistency. 